### PR TITLE
feat: implement edit command for story editing via CLI

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -116,6 +116,7 @@ pub trait ShortcutApi {
     fn search_stories(&self, query: &str, limit: Option<usize>) -> Result<Vec<Story>>;
     fn search_stories_page(&self, query: &str, next_token: Option<String>) -> Result<SearchStoriesResult>;
     fn get_workflows(&self) -> Result<Vec<Workflow>>;
+    fn get_story(&self, story_id: i64) -> Result<Story>;
     fn update_story_state(&self, story_id: i64, workflow_state_id: i64) -> Result<Story>;
     fn get_current_member(&self) -> Result<CurrentMember>;
     fn update_story(&self, story_id: i64, owner_ids: Vec<String>) -> Result<Story>;

--- a/src/story_creator/tests.rs
+++ b/src/story_creator/tests.rs
@@ -18,6 +18,10 @@ mod tests {
             unimplemented!()
         }
 
+        fn get_story(&self, _story_id: i64) -> Result<Story> {
+            unimplemented!()
+        }
+
         fn update_story_state(&self, _story_id: i64, _workflow_state_id: i64) -> Result<Story> {
             unimplemented!()
         }

--- a/src/story_editor.rs
+++ b/src/story_editor.rs
@@ -1,0 +1,158 @@
+use anyhow::{Context, Result};
+use dialoguer::{Input, Select, Confirm};
+use crate::api::{ShortcutApi, Story};
+use std::io::{self, BufRead};
+
+#[cfg(test)]
+mod tests;
+
+pub struct StoryEditor {
+    pub story_id: i64,
+    pub name: String,
+    pub description: String,
+    pub story_type: String,
+}
+
+impl StoryEditor {
+    /// Create a new StoryEditor from an existing story
+    pub fn from_story(story: &Story) -> Self {
+        Self {
+            story_id: story.id,
+            name: story.name.clone(),
+            description: story.description.clone(),
+            story_type: story.story_type.clone(),
+        }
+    }
+
+    /// Interactive prompt to edit story details with pre-filled current values
+    pub fn edit_with_prompts(&mut self) -> Result<bool> {
+        println!("\n🔧 Editing Story #{}", self.story_id);
+        println!("Press Enter to keep current values, or type new values to change them.\n");
+
+        // Edit story name
+        let new_name: String = Input::new()
+            .with_prompt("Story name")
+            .with_initial_text(&self.name)
+            .interact_text()
+            .context("Failed to read story name")?;
+
+        // Edit description with multi-line support
+        println!("\nCurrent description:");
+        if self.description.is_empty() {
+            println!("  (no description)");
+        } else {
+            for line in self.description.lines() {
+                println!("  {}", line);
+            }
+        }
+
+        let edit_description = Confirm::new()
+            .with_prompt("Do you want to edit the description?")
+            .default(false)
+            .interact()
+            .context("Failed to read confirmation")?;
+
+        let new_description = if edit_description {
+            println!("\nEnter new description (press Enter twice to finish):");
+            let mut description_lines = Vec::new();
+            let mut empty_line_count = 0;
+            
+            let stdin = io::stdin();
+            let mut handle = stdin.lock();
+            
+            loop {
+                let mut line = String::new();
+                handle.read_line(&mut line).context("Failed to read line")?;
+                
+                // Remove the newline character
+                let line = line.trim_end_matches('\n').trim_end_matches('\r').to_string();
+                
+                if line.is_empty() {
+                    empty_line_count += 1;
+                    if empty_line_count >= 2 {
+                        break;
+                    }
+                    description_lines.push(String::new());
+                } else {
+                    empty_line_count = 0;
+                    description_lines.push(line);
+                }
+            }
+            
+            // Remove trailing empty lines
+            while description_lines.last() == Some(&String::new()) {
+                description_lines.pop();
+            }
+            
+            description_lines.join("\n")
+        } else {
+            self.description.clone()
+        };
+
+        // Edit story type
+        let story_types = vec!["feature", "bug", "chore"];
+        let current_type_index = story_types.iter()
+            .position(|&t| t == self.story_type)
+            .unwrap_or(0);
+
+        let story_type_index = Select::new()
+            .with_prompt("Story type")
+            .items(&story_types)
+            .default(current_type_index)
+            .interact()
+            .context("Failed to read story type")?;
+
+        let new_story_type = story_types[story_type_index].to_string();
+
+        // Check if anything changed
+        let changed = new_name != self.name || 
+                     new_description != self.description || 
+                     new_story_type != self.story_type;
+
+        if !changed {
+            println!("\n📝 No changes made to the story.");
+            return Ok(false);
+        }
+
+        // Update the struct with new values
+        self.name = new_name;
+        self.description = new_description;
+        self.story_type = new_story_type;
+
+        // Show summary of changes
+        println!("\n📋 Summary of changes:");
+        println!("  Name: {}", self.name);
+        println!("  Type: {}", self.story_type);
+        if self.description.is_empty() {
+            println!("  Description: (empty)");
+        } else {
+            let first_line = self.description.lines().next().unwrap_or("");
+            println!("  Description: {}...", 
+                if first_line.len() > 50 { 
+                    &first_line[..50] 
+                } else { 
+                    first_line 
+                });
+        }
+
+        // Confirm changes
+        let confirm = Confirm::new()
+            .with_prompt("Save these changes?")
+            .default(true)
+            .interact()
+            .context("Failed to read confirmation")?;
+
+        Ok(confirm)
+    }
+
+    /// Update the story using the API client
+    pub fn update<T: ShortcutApi>(&self, client: &T) -> Result<Story> {
+        client.update_story_details(
+            self.story_id,
+            self.name.clone(),
+            self.description.clone(),
+            self.story_type.clone()
+        )
+        .context("Failed to update story")
+    }
+}

--- a/src/story_editor/tests.rs
+++ b/src/story_editor/tests.rs
@@ -1,0 +1,29 @@
+use super::*;
+use crate::api::Story;
+
+#[test]
+fn test_story_editor_from_story() {
+    let story = Story {
+        id: 123,
+        name: "Test Story".to_string(),
+        description: "Test description".to_string(),
+        workflow_state_id: 1,
+        app_url: "https://example.com".to_string(),
+        story_type: "feature".to_string(),
+        labels: vec![],
+        owner_ids: vec![],
+        position: 1,
+        created_at: "2023-01-01T00:00:00Z".to_string(),
+        updated_at: "2023-01-01T00:00:00Z".to_string(),
+        completed_at: None,
+        moved_at: None,
+        comments: vec![],
+    };
+
+    let editor = StoryEditor::from_story(&story);
+
+    assert_eq!(editor.story_id, 123);
+    assert_eq!(editor.name, "Test Story");
+    assert_eq!(editor.description, "Test description");
+    assert_eq!(editor.story_type, "feature");
+}


### PR DESCRIPTION
## Summary
- Implements a new `edit` subcommand that allows users to edit existing stories via the CLI
- Takes a story ID as argument and provides interactive prompts with pre-filled current values
- Supports editing story name, description, and type (feature/bug/chore)

## Changes Made
- Added new `Edit` command variant to the CLI parser
- Created `StoryEditor` struct for handling interactive story editing logic
- Added `get_story` method to `ShortcutApi` trait and client implementation
- Implemented interactive prompts using `dialoguer` with pre-filled values:
  - Story name: Input field with current name as initial text
  - Description: Multi-line editing with confirmation prompt to avoid accidental changes
  - Story type: Select dropdown with current type as default selection
- Added comprehensive error handling for story not found (404), API errors, etc.
- Supports both workspace and token-based authentication methods
- Includes confirmation step before saving changes and shows summary of changes
- Added unit tests for new `StoryEditor` functionality
- Updated existing mock tests to include the new `get_story` method

## Usage Examples
```bash
# Edit story using workspace config
sc-cli edit 12345 --workspace myworkspace

# Edit story using token
sc-cli edit 12345 --token YOUR_API_TOKEN

# With debug output
sc-cli edit 12345 --workspace myworkspace --debug
```

## Test Plan
- [x] All existing tests pass
- [x] New unit tests for `StoryEditor` pass
- [x] CLI help shows the new edit command correctly
- [x] Compilation works for both debug and release builds
- [x] Integration with existing authentication methods (workspace/token)
- [x] Error handling for invalid story IDs and API failures

🤖 Generated with [Claude Code](https://claude.ai/code)